### PR TITLE
A zeroed cyphertext should be considered as an account balance of 0

### DIFF
--- a/crypto/src/instruction/close_account.rs
+++ b/crypto/src/instruction/close_account.rs
@@ -108,6 +108,9 @@ impl CloseAccountProof {
         let z = self.z.into();
 
         // generate a challenge scalar
+        //
+        // use `append_point` as opposed to `validate_and_append_point` as the ciphertext is
+        // already guaranteed to be well-formed
         transcript.append_point(b"R", &R);
         let c = transcript.challenge_scalar(b"c");
 

--- a/crypto/src/instruction/update_account_pk.rs
+++ b/crypto/src/instruction/update_account_pk.rs
@@ -227,5 +227,42 @@ mod test {
 
         let proof = UpdateAccountPkProof::new(balance, &current_sk, &new_sk, &current_ct, &new_ct);
         assert!(proof.verify(&current_ct, &new_ct).is_err());
+
+        // A zeroed cipehrtext should be considered as an account balance of 0
+        let balance: u64 = 0;
+        let zeroed_ct_as_current_ct: ElGamalCT = PodElGamalCT::zeroed().try_into().unwrap();
+        let new_ct: ElGamalCT = new_pk.encrypt(balance);
+        let proof = UpdateAccountPkProof::new(
+            balance,
+            &current_sk,
+            &new_sk,
+            &zeroed_ct_as_current_ct,
+            &new_ct,
+        );
+        assert!(proof.verify(&zeroed_ct_as_current_ct, &new_ct).is_ok());
+
+        let current_ct: ElGamalCT = PodElGamalCT::zeroed().try_into().unwrap();
+        let zeroed_ct_as_new_ct: ElGamalCT = PodElGamalCT::zeroed().try_into().unwrap();
+        let proof = UpdateAccountPkProof::new(
+            balance,
+            &current_sk,
+            &new_sk,
+            &current_ct,
+            &zeroed_ct_as_new_ct,
+        );
+        assert!(proof.verify(&current_ct, &zeroed_ct_as_new_ct).is_ok());
+
+        let zeroed_ct_as_current_ct: ElGamalCT = PodElGamalCT::zeroed().try_into().unwrap();
+        let zeroed_ct_as_new_ct: ElGamalCT = PodElGamalCT::zeroed().try_into().unwrap();
+        let proof = UpdateAccountPkProof::new(
+            balance,
+            &current_sk,
+            &new_sk,
+            &zeroed_ct_as_current_ct,
+            &zeroed_ct_as_new_ct,
+        );
+        assert!(proof
+            .verify(&zeroed_ct_as_current_ct, &zeroed_ct_as_new_ct)
+            .is_ok());
     }
 }


### PR DESCRIPTION
But it's not?
```
running 1 test
test instruction::close_account::test::test_close_account_correctness ... FAILED

failures:

---- instruction::close_account::test::test_close_account_correctness stdout ----
thread 'instruction::close_account::test::test_close_account_correctness' panicked at 'assertion failed: proof.verify(&balance).is_ok()', crypto/src/instruction/close_account.rs:150:9
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace


failures:
    instruction::close_account::test::test_close_account_correctness
```