### PR TITLE
Add Withdraw test

### DIFF
--- a/program/src/processor.rs
+++ b/program/src/processor.rs
@@ -624,8 +624,8 @@ fn process_withdraw(accounts: &[AccountInfo], amount: u64, decimals: u8) -> Prog
     let confidential_account_info = next_account_info(account_info_iter)?;
     let token_account_info = next_account_info(account_info_iter)?;
     let dest_token_account_info = next_account_info(account_info_iter)?;
-    let omnibus_info = next_account_info(account_info_iter)?;
     let mint_info = next_account_info(account_info_iter)?;
+    let omnibus_info = next_account_info(account_info_iter)?;
     let spl_token_program_info = next_account_info(account_info_iter)?;
     let instructions_sysvar_info = next_account_info(account_info_iter)?;
     let owner_info = next_account_info(account_info_iter)?;
@@ -648,9 +648,13 @@ fn process_withdraw(accounts: &[AccountInfo], amount: u64, decimals: u8) -> Prog
         &previous_instruction,
     )?;
 
+    // TODO: THIS IS WRONG. IT EXISTS TEMPORARILY ONLY TO PACIFY CLIPPY
+    confidential_account.available_balance = data.final_balance_ct;
+    /*
     confidential_account.available_balance =
         sub_to_pod_ciphertext(confidential_account.available_balance, amount)
             .map_err(|_| ProgramError::InvalidInstructionData)?;
+    */
 
     if confidential_account.available_balance != data.final_balance_ct {
         msg!("Available balance mismatch");


### PR DESCRIPTION
As expected, `sub_to_pod_ciphertext()` blows up the BPF stack and is commented out for now until the syscall is implemented.  But otherwise the basic Withdraw instruction seems to work 