### PR TITLE
Demonstrate that the transfer range proof transaction is 198 bytes too big

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4738,6 +4738,7 @@ name = "spl-zk-token"
 version = "0.1.0"
 dependencies = [
  "assert_matches",
+ "bincode",
  "bytemuck",
  "getrandom 0.1.16",
  "num-derive",
@@ -4746,6 +4747,7 @@ dependencies = [
  "solana-program-test",
  "solana-sdk",
  "solana-validator",
+ "spl-memo",
  "spl-token",
  "spl-zk-token-crypto",
  "spl-zk-token-proof",

--- a/program/Cargo.toml
+++ b/program/Cargo.toml
@@ -14,6 +14,7 @@ num-derive = "0.3"
 num-traits = "0.2"
 solana-program = "=1.7.11"
 spl-token = { version = "3.2.0", features = ["no-entrypoint"] }
+spl-memo = { version = "3", features = ["no-entrypoint"] }
 spl-zk-token-crypto = { path = "../crypto" }
 
 [features]
@@ -25,6 +26,7 @@ solana-program-test = "=1.7.11"
 solana-sdk = "=1.7.11"
 solana-validator = "=1.7.11"
 spl-zk-token-proof= { path = "../proof-program" }
+bincode = "1.3.1"
 
 [lib]
 crate-type = ["cdylib", "lib"]


### PR DESCRIPTION
🤕  oof, 198 bytes over budget:
```
thread 'test_transfer' panicked at '1430 too big; max 1232', program/tests/functional.rs:649:5
```

Will look tomorrow to see if we can reduce the number of accounts needed for TransferRangeProof :-/


TransferValidityProof has enough headroom for this memo, so we're ok there at least:
`"A memo in the transfer validity proof transaction....."`