### PR TITLE
Add sol_zk_token_elgamal syscall declarations

### DIFF
--- a/program/src/processor.rs
+++ b/program/src/processor.rs
@@ -611,7 +611,7 @@ fn process_deposit(accounts: &[AccountInfo], amount: u64, decimals: u8) -> Progr
     )?;
 
     confidential_account.pending_balance =
-        ops::add_to(confidential_account.pending_balance, amount)
+        ops::add_to(&confidential_account.pending_balance, amount)
             .ok_or(ProgramError::InvalidInstructionData)?;
 
     Ok(())
@@ -649,7 +649,7 @@ fn process_withdraw(accounts: &[AccountInfo], amount: u64, decimals: u8) -> Prog
     )?;
 
     confidential_account.available_balance =
-        ops::subtract_from(confidential_account.available_balance, amount)
+        ops::subtract_from(&confidential_account.available_balance, amount)
             .ok_or(ProgramError::InvalidInstructionData)?;
 
     if confidential_account.available_balance != data.final_balance_ct {
@@ -760,9 +760,9 @@ fn process_transfer_common(
         ));
 
         confidential_account.available_balance = ops::subtract_with_lo_hi(
-            confidential_account.available_balance,
-            source_lo_ct,
-            source_hi_ct,
+            &confidential_account.available_balance,
+            &source_lo_ct,
+            &source_hi_ct,
         )
         .ok_or(ProgramError::InvalidInstructionData)?;
     }
@@ -787,9 +787,9 @@ fn process_transfer_common(
         ));
 
         receiver_confidential_account.pending_balance = ops::add_with_lo_hi(
-            receiver_confidential_account.pending_balance,
-            dest_lo_ct,
-            dest_hi_ct,
+            &receiver_confidential_account.pending_balance,
+            &dest_lo_ct,
+            &dest_hi_ct,
         )
         .ok_or(ProgramError::InvalidInstructionData)?;
     }
@@ -916,10 +916,11 @@ fn process_apply_pending_balance(accounts: &[AccountInfo]) -> ProgramResult {
     )?;
 
     confidential_account.available_balance = ops::add(
-        confidential_account.available_balance,
-        confidential_account.pending_balance,
+        &confidential_account.available_balance,
+        &confidential_account.pending_balance,
     )
     .ok_or(ProgramError::InvalidInstructionData)?;
+    confidential_account.pending_balance = pod::ElGamalCiphertext::zeroed();
 
     Ok(())
 }

--- a/sdk/src/zk_token_elgamal/ops.rs
+++ b/sdk/src/zk_token_elgamal/ops.rs
@@ -13,69 +13,69 @@ mod target_arch {
     // returns `Some(x0*ct0 + x1*ct1)` or `None` if the input was invalid
     fn add_ciphertexts(
         scalar_0: Scalar,
-        ct_0: pod::ElGamalCiphertext,
+        ct_0: &pod::ElGamalCiphertext,
         scalar_1: Scalar,
-        ct_1: pod::ElGamalCiphertext,
+        ct_1: &pod::ElGamalCiphertext,
     ) -> Option<pod::ElGamalCiphertext> {
-        let ct_0: ElGamalCiphertext = ct_0.try_into().ok()?;
-        let ct_1: ElGamalCiphertext = ct_1.try_into().ok()?;
+        let ct_0: ElGamalCiphertext = (*ct_0).try_into().ok()?;
+        let ct_1: ElGamalCiphertext = (*ct_1).try_into().ok()?;
 
         let ct_sum = ct_0 * scalar_0 + ct_1 * scalar_1;
         Some(pod::ElGamalCiphertext::from(ct_sum))
     }
 
     pub(crate) fn combine_lo_hi(
-        ct_lo: pod::ElGamalCiphertext,
-        ct_hi: pod::ElGamalCiphertext,
+        ct_lo: &pod::ElGamalCiphertext,
+        ct_hi: &pod::ElGamalCiphertext,
     ) -> Option<pod::ElGamalCiphertext> {
         add_ciphertexts(Scalar::one(), ct_lo, Scalar::from(TWO_32), ct_hi)
     }
 
     pub fn add(
-        ct_0: pod::ElGamalCiphertext,
-        ct_1: pod::ElGamalCiphertext,
+        ct_0: &pod::ElGamalCiphertext,
+        ct_1: &pod::ElGamalCiphertext,
     ) -> Option<pod::ElGamalCiphertext> {
         add_ciphertexts(Scalar::one(), ct_0, Scalar::one(), ct_1)
     }
 
     pub fn add_with_lo_hi(
-        ct_0: pod::ElGamalCiphertext,
-        ct_1_lo: pod::ElGamalCiphertext,
-        ct_1_hi: pod::ElGamalCiphertext,
+        ct_0: &pod::ElGamalCiphertext,
+        ct_1_lo: &pod::ElGamalCiphertext,
+        ct_1_hi: &pod::ElGamalCiphertext,
     ) -> Option<pod::ElGamalCiphertext> {
         let ct_1 = combine_lo_hi(ct_1_lo, ct_1_hi)?;
-        add_ciphertexts(Scalar::one(), ct_0, Scalar::one(), ct_1)
+        add_ciphertexts(Scalar::one(), ct_0, Scalar::one(), &ct_1)
     }
 
     pub fn subtract(
-        ct_0: pod::ElGamalCiphertext,
-        ct_1: pod::ElGamalCiphertext,
+        ct_0: &pod::ElGamalCiphertext,
+        ct_1: &pod::ElGamalCiphertext,
     ) -> Option<pod::ElGamalCiphertext> {
         add_ciphertexts(Scalar::one(), ct_0, -Scalar::one(), ct_1)
     }
 
     pub fn subtract_with_lo_hi(
-        ct_0: pod::ElGamalCiphertext,
-        ct_1_lo: pod::ElGamalCiphertext,
-        ct_1_hi: pod::ElGamalCiphertext,
+        ct_0: &pod::ElGamalCiphertext,
+        ct_1_lo: &pod::ElGamalCiphertext,
+        ct_1_hi: &pod::ElGamalCiphertext,
     ) -> Option<pod::ElGamalCiphertext> {
         let ct_1 = combine_lo_hi(ct_1_lo, ct_1_hi)?;
-        add_ciphertexts(Scalar::one(), ct_0, -Scalar::one(), ct_1)
+        add_ciphertexts(Scalar::one(), ct_0, -Scalar::one(), &ct_1)
     }
 
-    pub fn add_to(ct: pod::ElGamalCiphertext, amount: u64) -> Option<pod::ElGamalCiphertext> {
+    pub fn add_to(ct: &pod::ElGamalCiphertext, amount: u64) -> Option<pod::ElGamalCiphertext> {
         let mut amount_as_ct = [0_u8; 64];
         amount_as_ct[..32].copy_from_slice(RISTRETTO_BASEPOINT_COMPRESSED.as_bytes());
         add_ciphertexts(
             Scalar::one(),
             ct,
             Scalar::from(amount),
-            pod::ElGamalCiphertext(amount_as_ct),
+            &pod::ElGamalCiphertext(amount_as_ct),
         )
     }
 
     pub fn subtract_from(
-        ct: pod::ElGamalCiphertext,
+        ct: &pod::ElGamalCiphertext,
         amount: u64,
     ) -> Option<pod::ElGamalCiphertext> {
         let mut amount_as_ct = [0_u8; 64];
@@ -84,7 +84,7 @@ mod target_arch {
             Scalar::one(),
             ct,
             -Scalar::from(amount),
-            pod::ElGamalCiphertext(amount_as_ct),
+            &pod::ElGamalCiphertext(amount_as_ct),
         )
     }
 }
@@ -92,48 +92,141 @@ mod target_arch {
 #[cfg(target_arch = "bpf")]
 #[allow(unused_variables)]
 mod target_arch {
-    use crate::zk_token_elgamal::pod;
+    use {super::*, crate::zk_token_elgamal::pod, bytemuck::Zeroable};
+
+    fn op(
+        op: u64,
+        ct_0: &pod::ElGamalCiphertext,
+        ct_1: &pod::ElGamalCiphertext,
+    ) -> Option<pod::ElGamalCiphertext> {
+        let mut ct_result = pod::ElGamalCiphertext::zeroed();
+        let result = unsafe {
+            sol_zk_token_elgamal_op(
+                op,
+                &ct_0.0 as *const u8,
+                &ct_1.0 as *const u8,
+                &mut ct_result.0 as *mut u8,
+            )
+        };
+
+        if result == 0 {
+            Some(ct_result)
+        } else {
+            None
+        }
+    }
+
+    fn op_with_lo_hi(
+        op: u64,
+        ct_0: &pod::ElGamalCiphertext,
+        ct_1_lo: &pod::ElGamalCiphertext,
+        ct_1_hi: &pod::ElGamalCiphertext,
+    ) -> Option<pod::ElGamalCiphertext> {
+        let mut ct_result = pod::ElGamalCiphertext::zeroed();
+        let result = unsafe {
+            sol_zk_token_elgamal_op_with_lo_hi(
+                op,
+                &ct_0.0 as *const u8,
+                &ct_1_lo.0 as *const u8,
+                &ct_1_hi.0 as *const u8,
+                &mut ct_result.0 as *mut u8,
+            )
+        };
+
+        if result == 0 {
+            Some(ct_result)
+        } else {
+            None
+        }
+    }
+
+    fn op_with_scalar(
+        op: u64,
+        ct: &pod::ElGamalCiphertext,
+        scalar: u64,
+    ) -> Option<pod::ElGamalCiphertext> {
+        let mut ct_result = pod::ElGamalCiphertext::zeroed();
+        let result = unsafe {
+            sol_zk_token_elgamal_op_with_scalar(
+                op,
+                &ct.0 as *const u8,
+                scalar,
+                &mut ct_result.0 as *mut u8,
+            )
+        };
+
+        if result == 0 {
+            Some(ct_result)
+        } else {
+            None
+        }
+    }
 
     pub fn add(
-        ct_0: pod::ElGamalCiphertext,
-        ct_1: pod::ElGamalCiphertext,
+        ct_0: &pod::ElGamalCiphertext,
+        ct_1: &pod::ElGamalCiphertext,
     ) -> Option<pod::ElGamalCiphertext> {
-        None
+        op(OP_ADD, ct_0, ct_1)
     }
 
     pub fn add_with_lo_hi(
-        ct_0: pod::ElGamalCiphertext,
-        ct_1_lo: pod::ElGamalCiphertext,
-        ct_1_hi: pod::ElGamalCiphertext,
+        ct_0: &pod::ElGamalCiphertext,
+        ct_1_lo: &pod::ElGamalCiphertext,
+        ct_1_hi: &pod::ElGamalCiphertext,
     ) -> Option<pod::ElGamalCiphertext> {
-        None
+        op_with_lo_hi(OP_ADD, ct_0, ct_1_lo, ct_1_hi)
     }
 
     pub fn subtract(
-        ct_0: pod::ElGamalCiphertext,
-        ct_1: pod::ElGamalCiphertext,
+        ct_0: &pod::ElGamalCiphertext,
+        ct_1: &pod::ElGamalCiphertext,
     ) -> Option<pod::ElGamalCiphertext> {
-        None
+        op(OP_SUB, ct_0, ct_1)
     }
 
     pub fn subtract_with_lo_hi(
-        ct_0: pod::ElGamalCiphertext,
-        ct_1_lo: pod::ElGamalCiphertext,
-        ct_1_hi: pod::ElGamalCiphertext,
+        ct_0: &pod::ElGamalCiphertext,
+        ct_1_lo: &pod::ElGamalCiphertext,
+        ct_1_hi: &pod::ElGamalCiphertext,
     ) -> Option<pod::ElGamalCiphertext> {
-        None
+        op_with_lo_hi(OP_SUB, ct_0, ct_1_lo, ct_1_hi)
     }
 
-    pub fn add_to(ct: pod::ElGamalCiphertext, amount: u64) -> Option<pod::ElGamalCiphertext> {
-        None
+    pub fn add_to(ct: &pod::ElGamalCiphertext, amount: u64) -> Option<pod::ElGamalCiphertext> {
+        op_with_scalar(OP_ADD, ct, amount)
     }
 
     pub fn subtract_from(
-        ct: pod::ElGamalCiphertext,
+        ct: &pod::ElGamalCiphertext,
         amount: u64,
     ) -> Option<pod::ElGamalCiphertext> {
-        None
+        op_with_scalar(OP_SUB, ct, amount)
     }
+}
+
+pub const OP_ADD: u64 = 0;
+pub const OP_SUB: u64 = 1;
+
+extern "C" {
+    pub fn sol_zk_token_elgamal_op(
+        op: u64,
+        ct_0: *const u8,
+        ct_1: *const u8,
+        ct_result: *mut u8,
+    ) -> u64;
+    pub fn sol_zk_token_elgamal_op_with_lo_hi(
+        op: u64,
+        ct_0: *const u8,
+        ct_1_lo: *const u8,
+        ct_1_hi: *const u8,
+        ct_result: *mut u8,
+    ) -> u64;
+    pub fn sol_zk_token_elgamal_op_with_scalar(
+        op: u64,
+        ct: *const u8,
+        scalar: u64,
+        ct_result: *mut u8,
+    ) -> u64;
 }
 
 #[cfg(test)]


### PR DESCRIPTION
Matching syscall implementation is at https://github.com/solana-labs/solana/pull/19508/files (see changes to programs/bpf_loader/src/syscalls.rs in that PR)

I managed to reduce down to only 3 syscalls, and `cargo-test-bpf` now passes locally with the syscalls.



