### PR TITLE
Add inner instruction utility functions

### DIFF
--- a/demo/src/main.rs
+++ b/demo/src/main.rs
@@ -340,7 +340,7 @@ fn process_demo(
             &token_mint.pubkey(),
             payer.pubkey(),
             &[],
-            transfer_data,
+            &transfer_data,
         ),
         &[payer],
     )?;
@@ -400,7 +400,7 @@ fn process_demo(
             &[],
             current_balance_b,
             0,
-            spl_zk_token::instruction::WithdrawData::new(
+            &spl_zk_token::instruction::WithdrawData::new(
                 current_balance_b,
                 elgamal_pk_a,
                 &elgamal_sk_b,

--- a/program/tests/functional.rs
+++ b/program/tests/functional.rs
@@ -392,7 +392,7 @@ async fn test_close_account() {
             reclaim_account.pubkey(),
             owner.pubkey(),
             &[],
-            data,
+            &data,
         ),
         Some(&payer.pubkey()),
     );
@@ -458,7 +458,7 @@ async fn test_update_account_pk() {
             token_account,
             owner.pubkey(),
             &[],
-            data,
+            &data,
         ),
         Some(&payer.pubkey()),
     );
@@ -609,7 +609,7 @@ async fn test_withdraw() {
             &[],
             1,
             DECIMALS,
-            withdraw_data,
+            &withdraw_data,
         ),
         Some(&payer.pubkey()),
     );
@@ -689,7 +689,7 @@ async fn test_transfer() {
         &mint,
         owner.pubkey(),
         &[],
-        transfer_data,
+        &transfer_data,
     );
 
     instructions.push(spl_memo::build_memo(

--- a/sdk/src/zk_token_proof_instruction.rs
+++ b/sdk/src/zk_token_proof_instruction.rs
@@ -79,3 +79,19 @@ impl ProofInstruction {
         }
     }
 }
+
+pub fn verify_close_account(proof_data: &CloseAccountData) -> Instruction {
+    ProofInstruction::VerifyCloseAccount.encode(proof_data)
+}
+
+pub fn verify_update_account_pk(proof_data: &UpdateAccountPkData) -> Instruction {
+    ProofInstruction::VerifyUpdateAccountPk.encode(proof_data)
+}
+
+pub fn verify_withdraw(proof_data: &WithdrawData) -> Instruction {
+    ProofInstruction::VerifyWithdraw.encode(proof_data)
+}
+
+pub fn verify_transfer(proof_data: &TransferData) -> Instruction {
+    ProofInstruction::VerifyTransfer.encode(proof_data)
+}


### PR DESCRIPTION
It's likely that somebody will eventually want to `invoke()` a transfer or withdraw instruction from their program.  This is possible but the proof instruction must still be provided as the preceding instruction.  

cc: https://github.com/solana-labs/solana/pull/20604