### PR TITLE
ElGamal keypair from Ed25519 keypair

### DIFF
--- a/sdk/Cargo.toml
+++ b/sdk/Cargo.toml
@@ -22,7 +22,6 @@ bincode = "1"
 byteorder = "1"
 cipher = "0.3"
 curve25519-dalek = { version = "3.2.0", features = ["serde"]}
-ed25519-dalek = "=1.0.1"
 getrandom = { version = "0.1", features = ["dummy"] }
 merlin = "2"
 rand = "0.7"

--- a/sdk/src/encryption/aes.rs
+++ b/sdk/src/encryption/aes.rs
@@ -6,8 +6,8 @@ use {
 };
 use {
     arrayref::{array_ref, array_refs},
-    ed25519_dalek::SecretKey as SigningKey,
     solana_sdk::pubkey::Pubkey,
+    solana_sdk::signature::Keypair as SigningKeypair,
     std::convert::TryInto,
     zeroize::Zeroize,
 };
@@ -54,9 +54,9 @@ impl Aes {
 #[derive(Debug, Zeroize)]
 pub struct AesKey([u8; 16]);
 impl AesKey {
-    pub fn new(signing_key: &SigningKey, address: &Pubkey) -> Self {
+    pub fn new(signing_keypair: &SigningKeypair, address: &Pubkey) -> Self {
         let mut hashable = [0_u8; 64];
-        hashable[..32].copy_from_slice(&signing_key.to_bytes());
+        hashable[..32].copy_from_slice(&signing_keypair.secret().to_bytes());
         hashable[32..].copy_from_slice(&address.to_bytes());
 
         let mut hasher = Sha3_256::new();

--- a/sdk/src/encryption/elgamal.rs
+++ b/sdk/src/encryption/elgamal.rs
@@ -11,9 +11,9 @@ use {
         ristretto::{CompressedRistretto, RistrettoPoint},
         scalar::Scalar,
     },
-    ed25519_dalek::Keypair as SigningKeyPair,
     serde::{Deserialize, Serialize},
     solana_sdk::pubkey::Pubkey,
+    solana_sdk::signature::Keypair as SigningKeypair,
     std::collections::HashMap,
     std::convert::TryInto,
     subtle::{Choice, ConstantTimeEq},
@@ -136,8 +136,8 @@ impl ElGamalKeypair {
     /// address.
     #[cfg(not(target_arch = "bpf"))]
     #[allow(non_snake_case)]
-    pub fn new(signing_key_pair: &SigningKeyPair, address: &Pubkey) -> Self {
-        let secret = ElGamalSecretKey::new(signing_key_pair, address);
+    pub fn new(signing_keypair: &SigningKeypair, address: &Pubkey) -> Self {
+        let secret = ElGamalSecretKey::new(signing_keypair, address);
         let public = ElGamalPubkey::new(&secret);
 
         Self { public, secret }
@@ -292,11 +292,10 @@ impl fmt::Display for ElGamalPubkey {
 #[zeroize(drop)]
 pub struct ElGamalSecretKey(Scalar);
 impl ElGamalSecretKey {
-    pub fn new(signing_key_pair: &SigningKeyPair, address: &Pubkey) -> Self {
-        let mut hashable = [0_u8; 96];
-        hashable[..32].copy_from_slice(&signing_key_pair.secret.to_bytes());
-        hashable[32..64].copy_from_slice(&signing_key_pair.public.to_bytes());
-        hashable[64..].copy_from_slice(&address.to_bytes());
+    pub fn new(signing_keypair: &SigningKeypair, address: &Pubkey) -> Self {
+        let mut hashable = [0_u8; 64];
+        hashable[..32].copy_from_slice(&signing_keypair.secret().to_bytes());
+        hashable[32..].copy_from_slice(&address.to_bytes());
         ElGamalSecretKey(Scalar::hash_from_bytes::<Sha3_512>(&hashable))
     }
 


### PR DESCRIPTION
@mvines I changed the `ElGamalKeyPair` constructor to take in an Ed25519 keypair as opposed to just the signing key. The ElGamal key is now derived from the hash of both the Ed25519 secret and public keys. An Ed25519 public key is uniquely determined by its signing key, so this should be a syntactical change without any security implications. The address component can be set `Pubkey::default()` if the user does not wish to bind an ElGamal keypair to any specific zk-token account.