### PR TITLE
Generate AesKey/ElGamalSecretKey from an ed25519 signature instead of secret key

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4856,7 +4856,6 @@ dependencies = [
  "byteorder",
  "cipher",
  "curve25519-dalek 3.2.0",
- "ed25519-dalek",
  "getrandom 0.1.16",
  "merlin",
  "num-derive",


### PR DESCRIPTION
The Ledger devices will not share their secret key, so the previous method of using a hash of the ed25519 secret key to generate the AES and ElGamal secret key won't work.  Support Ledger is important and requiring the user to maintain filesystem-based companion AES/ElGamal keys to their Ledger is no bueno.  

So instead of using the secret key itself, sign a deterministic message with the ed25519 secret key and use that message signature as input.  This works on a Ledger device when the user enables blind signing, which they'll need to do in the short-term regardless to use the confidential token