### PR TITLE
Rename `incoming_transfer_count` to `pending_balance_instructions`

### DIFF
--- a/program/src/state.rs
+++ b/program/src/state.rs
@@ -29,8 +29,8 @@ pub struct ConfidentialAccount {
     pub mint: Pubkey,
 
     /// The SPL Token account that corresponds to this confidential token account.
-    /// The owner and close authority of the SPL Token account convey their authority over the
-    /// confidential token account
+    /// The owner of the SPL Token account convey their authority over the confidential token
+    /// account
     pub token_account: Pubkey,
 
     /// The public key associated with ElGamal encryption
@@ -48,87 +48,14 @@ pub struct ConfidentialAccount {
     /// Prohibit incoming transfers if `false`
     pub accept_incoming_transfers: PodBool,
 
-    /// Counts the number of incoming transfers
-    pub incoming_transfer_count: PodU64,
+    /// The total number of `Deposit` and `Transfer` instructions that have credited `pending_balance`
+    pub pending_balance_instructions: PodU64,
 
-    /// Record of `incoming_transfer_count` at the time of the most recent `ApplyPendingBalance`
-    pub applied_incoming_transfer_count: TransferCountRecord,
+    /// The expected `pending_balance_instructions` that was included in the last `ApplyPendingBalance`
+    /// instruction
+    pub expected_apply_pending_balance_instructions: PodU64,
+
+    /// The actual `pending_balance_instructions` at last time the `ApplyPendingBalance` was executed
+    pub actual_applied_pending_balance_instructions: PodU64,
 }
 impl PodAccountInfo<'_, '_> for ConfidentialAccount {}
-
-/// After submitting `ApplyPendingBalance`, the client should compare the expected and the actual
-/// transfer counts. If they are equal, then the `decryptable_balance` is consistent with
-/// `available_balance`. If they differ, then the client should update the `decryptable_balance`.
-#[repr(C)]
-#[derive(Clone, Copy, Pod, Zeroable)]
-pub struct TransferCountRecord {
-    /// The expected `incoming_transfer_count` that was included in the `ApplyPendingBalance`
-    /// instruction
-    pub expected_incoming_transfer_count: PodU64,
-
-    /// The actual `incoming_transfer_count` at the time the `ApplyPendingBalance` was executed
-    pub actual_incoming_transfer_count: PodU64,
-}
-
-#[cfg(test)]
-mod tests {
-    /*
-    use super::*;
-
-    #[test]
-    fn test_get_packed_len() {
-        assert_eq!(
-            Auditor::get_packed_len(),
-            solana_program::borsh::get_packed_len::<Auditor>()
-        );
-
-        assert_eq!(
-            ConfidentialAccount::get_packed_len(),
-            solana_program::borsh::get_packed_len::<ConfidentialAccount>()
-        );
-    }
-
-    #[test]
-    fn test_serialize_bytes() {
-        assert_eq!(FeatureProposal::Expired.try_to_vec().unwrap(), vec![3]);
-
-        assert_eq!(
-            FeatureProposal::Pending(AcceptanceCriteria {
-                tokens_required: 0xdeadbeefdeadbeef,
-                deadline: -1,
-            })
-            .try_to_vec()
-            .unwrap(),
-            vec![1, 239, 190, 173, 222, 239, 190, 173, 222, 255, 255, 255, 255, 255, 255, 255, 255],
-        );
-    }
-
-    #[test]
-    fn test_serialize_large_slice() {
-        let mut dst = vec![0xff; 4];
-        FeatureProposal::Expired.pack_into_slice(&mut dst);
-
-        // Extra bytes (0xff) ignored
-        assert_eq!(dst, vec![3, 0xff, 0xff, 0xff]);
-    }
-
-    #[test]
-    fn state_deserialize_invalid() {
-        assert_eq!(
-            FeatureProposal::unpack_from_slice(&[3]),
-            Ok(FeatureProposal::Expired),
-        );
-
-        // Extra bytes (0xff) ignored...
-        assert_eq!(
-            FeatureProposal::unpack_from_slice(&[3, 0xff, 0xff, 0xff]),
-            Ok(FeatureProposal::Expired),
-        );
-
-        assert_eq!(
-            FeatureProposal::unpack_from_slice(&[4]),
-            Err(ProgramError::InvalidAccountData),
-        );
-    }
-    */
-}

--- a/program/tests/functional.rs
+++ b/program/tests/functional.rs
@@ -490,7 +490,7 @@ async fn test_deposit() {
         u64::from(
             get_zk_token_state(&mut banks_client, zk_token_account)
                 .await
-                .incoming_transfer_count
+                .pending_balance_instructions
         ),
         1,
     );
@@ -501,7 +501,7 @@ async fn test_deposit() {
             token_account,
             owner.pubkey(),
             &[],
-            /*incoming_transfer_count=*/ 1,
+            /*pending_balance_instructions=*/ 1,
             AesCiphertext::default(),
         ),
         Some(&payer.pubkey()),
@@ -664,7 +664,7 @@ async fn test_transfer() {
         u64::from(
             get_zk_token_state(&mut banks_client, dst_zk_token_account)
                 .await
-                .incoming_transfer_count
+                .pending_balance_instructions
         ),
         1,
     );


### PR DESCRIPTION
"Incoming transfer" is a misnomer because Deposit instructions can also affect the pending balance. Generalize.