### PR TITLE
Clean up authenticated encryption and rename aes to auth_encryption

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -49,17 +49,18 @@ dependencies = [
 ]
 
 [[package]]
-name = "aes-gcm"
-version = "0.9.4"
+name = "aes-gcm-siv"
+version = "0.10.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df5f85a83a7d8b0442b6aa7b504b8212c1733da07b98aae43d4bc21b2cb3cdf6"
+checksum = "589c637f0e68c877bbd59a4599bbe849cac8e5f3e4b5a3ebae8f528cd218dcdc"
 dependencies = [
  "aead",
  "aes",
  "cipher",
  "ctr",
- "ghash",
+ "polyval",
  "subtle",
+ "zeroize",
 ]
 
 [[package]]
@@ -1440,16 +1441,6 @@ dependencies = [
  "cfg-if 1.0.0",
  "libc",
  "wasi 0.10.0+wasi-snapshot-preview1",
-]
-
-[[package]]
-name = "ghash"
-version = "0.4.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1583cc1656d7839fd3732b80cf4f38850336cdb9b8ded1cd399ca62958de3c99"
-dependencies = [
- "opaque-debug 0.3.0",
- "polyval",
 ]
 
 [[package]]
@@ -4848,7 +4839,7 @@ dependencies = [
 name = "spl-zk-token-sdk"
 version = "0.1.0"
 dependencies = [
- "aes-gcm",
+ "aes-gcm-siv",
  "arrayref",
  "base64 0.13.0",
  "bincode",
@@ -6060,9 +6051,9 @@ dependencies = [
 
 [[package]]
 name = "zeroize"
-version = "1.4.1"
+version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "377db0846015f7ae377174787dd452e1c5f5a9050bc6f954911d01f116daa0cd"
+checksum = "4756f7db3f7b5574938c3eb1c117038b8e07f95ee6718c0efad4ac21508f1efd"
 dependencies = [
  "zeroize_derive",
 ]

--- a/program/src/instruction.rs
+++ b/program/src/instruction.rs
@@ -2,7 +2,7 @@
 //!
 
 #[cfg(not(target_arch = "bpf"))]
-use spl_zk_token_sdk::encryption::{aes::AesCiphertext, elgamal::ElGamalPubkey};
+use spl_zk_token_sdk::encryption::{auth_encryption::AeCiphertext, elgamal::ElGamalPubkey};
 pub use spl_zk_token_sdk::zk_token_proof_instruction::*;
 use {
     crate::{pod::*, *},
@@ -24,7 +24,7 @@ pub struct ConfigureAccountInstructionData {
     /// The public key associated with the account
     pub elgamal_pk: pod::ElGamalPubkey,
     /// The decryptable balance (always 0) once the configure account succeeds
-    pub decryptable_zero_balance: pod::AesCiphertext,
+    pub decryptable_zero_balance: pod::AeCiphertext,
 }
 
 #[derive(Clone, Copy, Pod, Zeroable)]
@@ -44,14 +44,14 @@ pub struct WithdrawInstructionData {
     /// Expected number of base 10 digits to the right of the decimal place
     pub decimals: u8,
     /// The new decryptable balance if the withrawal succeeds
-    pub new_decryptable_available_balance: pod::AesCiphertext,
+    pub new_decryptable_available_balance: pod::AeCiphertext,
 }
 
 #[derive(Clone, Copy, Pod, Zeroable)]
 #[repr(C)]
 pub struct TransferInstructionData {
     /// The new source decryptable balance if the transfer succeeds
-    pub new_source_decryptable_available_balance: pod::AesCiphertext,
+    pub new_source_decryptable_available_balance: pod::AeCiphertext,
 }
 
 #[derive(Clone, Copy, Pod, Zeroable)]
@@ -61,7 +61,7 @@ pub struct ApplyPendingBalanceData {
     /// `ApplyPendingBalance` instruction
     pub expected_pending_balance_credit_counter: PodU64,
     /// The new decryptable balance if the pending balance is applied successfully
-    pub new_decryptable_available_balance: pod::AesCiphertext,
+    pub new_decryptable_available_balance: pod::AeCiphertext,
 }
 
 #[derive(Clone, Copy, Debug, FromPrimitive, ToPrimitive)]
@@ -413,7 +413,7 @@ pub fn configure_account(
     funding_address: Pubkey,
     zk_token_account: Pubkey,
     elgamal_pk: ElGamalPubkey,
-    decryptable_zero_balance: AesCiphertext,
+    decryptable_zero_balance: AeCiphertext,
     token_account: Pubkey,
     authority: Pubkey,
     multisig_signers: &[&Pubkey],
@@ -590,7 +590,7 @@ pub fn inner_withdraw(
     multisig_signers: &[&Pubkey],
     amount: u64,
     decimals: u8,
-    new_decryptable_available_balance: pod::AesCiphertext,
+    new_decryptable_available_balance: pod::AeCiphertext,
 ) -> Instruction {
     let mut accounts = vec![
         AccountMeta::new(source_zk_token_account, false),
@@ -630,7 +630,7 @@ pub fn withdraw(
     multisig_signers: &[&Pubkey],
     amount: u64,
     decimals: u8,
-    new_decryptable_available_balance: AesCiphertext,
+    new_decryptable_available_balance: AeCiphertext,
     proof_data: &WithdrawData,
 ) -> Vec<Instruction> {
     vec![
@@ -662,7 +662,7 @@ pub fn inner_transfer(
     mint: &Pubkey,
     authority: Pubkey,
     multisig_signers: &[&Pubkey],
-    new_source_decryptable_available_balance: pod::AesCiphertext,
+    new_source_decryptable_available_balance: pod::AeCiphertext,
 ) -> Instruction {
     let mut accounts = vec![
         AccountMeta::new(source_zk_token_account, false),
@@ -698,7 +698,7 @@ pub fn transfer(
     mint: &Pubkey,
     authority: Pubkey,
     multisig_signers: &[&Pubkey],
-    new_source_decryptable_available_balance: AesCiphertext,
+    new_source_decryptable_available_balance: AeCiphertext,
     proof_data: &TransferData,
 ) -> Vec<Instruction> {
     vec![
@@ -726,7 +726,7 @@ pub fn inner_apply_pending_balance(
     authority: Pubkey,
     multisig_signers: &[&Pubkey],
     expected_pending_balance_credit_counter: u64,
-    new_decryptable_available_balance: pod::AesCiphertext,
+    new_decryptable_available_balance: pod::AeCiphertext,
 ) -> Instruction {
     let mut accounts = vec![
         AccountMeta::new(zk_token_account, false),
@@ -756,7 +756,7 @@ pub fn apply_pending_balance(
     authority: Pubkey,
     multisig_signers: &[&Pubkey],
     pending_balance_instructions: u64,
-    new_decryptable_available_balance: AesCiphertext,
+    new_decryptable_available_balance: AeCiphertext,
 ) -> Vec<Instruction> {
     vec![inner_apply_pending_balance(
         zk_token_account,

--- a/program/src/processor.rs
+++ b/program/src/processor.rs
@@ -550,7 +550,7 @@ fn process_withdraw(
     accounts: &[AccountInfo],
     amount: u64,
     decimals: u8,
-    new_decryptable_available_balance: pod::AesCiphertext,
+    new_decryptable_available_balance: pod::AeCiphertext,
 ) -> ProgramResult {
     let account_info_iter = &mut accounts.iter();
 
@@ -634,7 +634,7 @@ fn process_withdraw(
 /// Processes a [Transfer] instruction.
 fn process_transfer(
     accounts: &[AccountInfo],
-    new_source_decryptable_available_balance: pod::AesCiphertext,
+    new_source_decryptable_available_balance: pod::AeCiphertext,
 ) -> ProgramResult {
     let account_info_iter = &mut accounts.iter();
     let zk_token_account_info = next_account_info(account_info_iter)?;
@@ -748,7 +748,7 @@ fn process_transfer(
 fn process_apply_pending_balance(
     accounts: &[AccountInfo],
     expected_pending_balance_credit_counter: PodU64,
-    new_decryptable_available_balance: pod::AesCiphertext,
+    new_decryptable_available_balance: pod::AeCiphertext,
 ) -> ProgramResult {
     let account_info_iter = &mut accounts.iter();
 

--- a/program/src/state.rs
+++ b/program/src/state.rs
@@ -5,7 +5,7 @@ use {
     spl_zk_token_sdk::zk_token_elgamal::pod,
 };
 #[cfg(not(target_arch = "bpf"))]
-use {spl_zk_token_sdk::encryption::aes::AesKey, std::convert::TryInto};
+use {spl_zk_token_sdk::encryption::auth_encryption::AeKey, std::convert::TryInto};
 
 /// Mint data
 #[derive(Clone, Copy, Pod, Zeroable)]
@@ -74,7 +74,7 @@ pub struct ZkAccount {
     pub available_balance: pod::ElGamalCiphertext,
 
     /// The decryptable available balance
-    pub decryptable_available_balance: pod::AesCiphertext,
+    pub decryptable_available_balance: pod::AeCiphertext,
 
     /// `pending_balance` may only be credited by `Deposit` or `Transfer` instructions if `true`
     pub allow_balance_credits: PodBool,
@@ -102,7 +102,7 @@ impl ZkAccount {
     }
 
     #[cfg(not(target_arch = "bpf"))]
-    pub fn decryptable_available_balance(&self, aes_key: &AesKey) -> Option<u64> {
+    pub fn decryptable_available_balance(&self, aes_key: &AeKey) -> Option<u64> {
         let decryptable_available_balance = self.decryptable_available_balance.try_into().ok()?;
         aes_key.decrypt(&decryptable_available_balance)
     }

--- a/program/tests/functional.rs
+++ b/program/tests/functional.rs
@@ -10,7 +10,7 @@ use {
     },
     spl_zk_token::{self, pod::*, state::Auditor, *},
     spl_zk_token_sdk::encryption::{
-        aes::AesCiphertext,
+        auth_encryption::AeCiphertext,
         elgamal::{ElGamalCiphertext, ElGamalKeypair, ElGamalPubkey},
     },
 };
@@ -344,7 +344,7 @@ async fn test_configure_account() {
             payer.pubkey(),
             zk_token_account,
             elgamal_pk,
-            AesCiphertext::default(),
+            AeCiphertext::default(),
             token_account,
             owner.pubkey(),
             &[],
@@ -509,7 +509,7 @@ async fn test_deposit() {
             owner.pubkey(),
             &[],
             /*expected_pending_balance_credit_counter=*/ 1,
-            AesCiphertext::default(),
+            AeCiphertext::default(),
         ),
         Some(&payer.pubkey()),
     );
@@ -573,7 +573,7 @@ async fn test_withdraw() {
             &[],
             1,
             DECIMALS,
-            AesCiphertext::default(),
+            AeCiphertext::default(),
             &withdraw_data,
         ),
         Some(&payer.pubkey()),
@@ -652,7 +652,7 @@ async fn test_transfer() {
         &mint,
         owner.pubkey(),
         &[],
-        AesCiphertext::default(),
+        AeCiphertext::default(),
         &transfer_data,
     );
 
@@ -684,7 +684,7 @@ async fn test_transfer() {
             owner.pubkey(),
             &[],
             1,
-            AesCiphertext::default(),
+            AeCiphertext::default(),
         ),
         Some(&payer.pubkey()),
     );
@@ -740,7 +740,7 @@ async fn test_transfer_self() {
             &mint,
             owner.pubkey(),
             &[],
-            AesCiphertext::default(),
+            AeCiphertext::default(),
             &transfer_data,
         ),
         Some(&payer.pubkey()),

--- a/sdk/Cargo.toml
+++ b/sdk/Cargo.toml
@@ -16,7 +16,7 @@ num-traits = "0.2"
 solana-program = "=1.7.15"
 
 [target.'cfg(not(target_arch = "bpf"))'.dependencies]
-aes-gcm = "0.9.4"
+aes-gcm-siv = "0.10.3"
 arrayref = "0.3.6"
 bincode = "1"
 byteorder = "1"

--- a/sdk/src/encryption/mod.rs
+++ b/sdk/src/encryption/mod.rs
@@ -1,4 +1,4 @@
-pub mod aes;
+pub mod auth_encryption;
 pub mod discrete_log;
 pub mod elgamal;
 pub mod pedersen;

--- a/sdk/src/zk_token_elgamal/convert.rs
+++ b/sdk/src/zk_token_elgamal/convert.rs
@@ -16,7 +16,7 @@ mod target_arch {
         super::pod,
         crate::{
             encryption::{
-                aes::AesCiphertext,
+                auth_encryption::AeCiphertext,
                 elgamal::{ElGamalCiphertext, ElGamalPubkey},
                 pedersen::{PedersenCommitment, PedersenDecryptHandle},
             },
@@ -128,16 +128,16 @@ mod target_arch {
         }
     }
 
-    impl From<AesCiphertext> for pod::AesCiphertext {
-        fn from(ct: AesCiphertext) -> Self {
+    impl From<AeCiphertext> for pod::AeCiphertext {
+        fn from(ct: AeCiphertext) -> Self {
             Self(ct.to_bytes())
         }
     }
 
-    impl TryFrom<pod::AesCiphertext> for AesCiphertext {
+    impl TryFrom<pod::AeCiphertext> for AeCiphertext {
         type Error = ProofError;
 
-        fn try_from(ct: pod::AesCiphertext) -> Result<Self, Self::Error> {
+        fn try_from(ct: pod::AeCiphertext) -> Result<Self, Self::Error> {
             Self::from_bytes(&ct.0).ok_or(ProofError::InconsistentCTData)
         }
     }

--- a/sdk/src/zk_token_elgamal/pod.rs
+++ b/sdk/src/zk_token_elgamal/pod.rs
@@ -89,17 +89,17 @@ pub struct RangeProof128(pub [u8; 736]);
 unsafe impl Zeroable for RangeProof128 {}
 unsafe impl Pod for RangeProof128 {}
 
-/// Serialization for AesCiphertext
+/// Serialization for AeCiphertext
 #[derive(Clone, Copy, PartialEq)]
 #[repr(transparent)]
-pub struct AesCiphertext(pub [u8; 36]);
+pub struct AeCiphertext(pub [u8; 36]);
 
-// `AesCiphertext` is a Pod and Zeroable.
+// `AeCiphertext` is a Pod and Zeroable.
 // Add the marker traits manually because `bytemuck` only adds them for some `u8` arrays
-unsafe impl Zeroable for AesCiphertext {}
-unsafe impl Pod for AesCiphertext {}
+unsafe impl Zeroable for AeCiphertext {}
+unsafe impl Pod for AeCiphertext {}
 
-impl fmt::Debug for AesCiphertext {
+impl fmt::Debug for AeCiphertext {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{:?}", self.0)
     }


### PR DESCRIPTION
- Switched authenticated encryption from using `AES-GCM` mode to `AES-GCM-SIV` mode of encryption. The latter is slightly slower but has additional mis-use resistance features.
- Renamed `aes` to `auth_encryption` as this more aptly describes the module.