### PR TITLE
Drop the twoxtx feature since we now always build against a compatible monorepo

### DIFF
--- a/program/Cargo.toml
+++ b/program/Cargo.toml
@@ -11,7 +11,6 @@ publish = false
 [features]
 no-entrypoint = []
 test-bpf = []
-twoxtx = [] # Enable tests that require 2x transaction size
 
 [dependencies]
 bytemuck = { version = "1.7.2", features = ["derive"] }

--- a/program/tests/functional.rs
+++ b/program/tests/functional.rs
@@ -1,5 +1,3 @@
-#![allow(unused_imports)] // Remove once the `twoxtx` feature no longer exists
-#![allow(dead_code)] // Remove once the `twoxtx` feature no longer exists
 use {
     bytemuck::Zeroable,
     solana_program::{program_pack::Pack, pubkey::Pubkey},
@@ -352,7 +350,6 @@ async fn test_configure_account() {
     assert_eq!(zk_token_state.allow_balance_credits, false.into());
 }
 
-#[cfg(feature = "twoxtx")]
 #[tokio::test]
 async fn test_close_account() {
     let owner = Keypair::new();
@@ -416,7 +413,6 @@ async fn test_close_account() {
 
 // Mark this test as BPF-only due to current `ProgramTest` limitations when CPIing into the SPL Token program
 #[cfg(feature = "test-bpf")]
-#[cfg(feature = "twoxtx")]
 #[tokio::test]
 async fn test_deposit() {
     let owner = Keypair::new();
@@ -510,7 +506,6 @@ async fn test_deposit() {
 
 // Mark this test as BPF-only due to current `ProgramTest` limitations when CPIing into the SPL Token program
 #[cfg(feature = "test-bpf")]
-#[cfg(feature = "twoxtx")]
 #[tokio::test]
 async fn test_withdraw() {
     let owner = Keypair::new();
@@ -582,7 +577,6 @@ async fn test_withdraw() {
     );
 }
 
-#[cfg(feature = "twoxtx")]
 #[tokio::test]
 async fn test_transfer() {
     let owner = Keypair::new();
@@ -681,7 +675,6 @@ async fn test_transfer() {
     // TODO: Check balance of dst_zk_token_account
 }
 
-#[cfg(feature = "twoxtx")]
 #[tokio::test]
 async fn test_transfer_self() {
     let owner = Keypair::new();


### PR DESCRIPTION
Unfortunately this surfaces new test errors ⚰️ 